### PR TITLE
Potential fix for code scanning alert no. 18: Log entries created from user input

### DIFF
--- a/scenarios/07-AgentsConcurrent/src/Insights/Generator.cs
+++ b/scenarios/07-AgentsConcurrent/src/Insights/Generator.cs
@@ -69,7 +69,8 @@ The output should be in the format 'Language:<detected language>', in example: '
         };
         db.UserQuestionInsight.Add(insight);
         await db.SaveChangesAsync();
-        _logger.LogInformation($"Added insight: {insight.Question}");
+        var sanitizedQuestion = insight.Question.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        _logger.LogInformation($"Added insight: {sanitizedQuestion}");
         return "OK";
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Azure-Samples/eShopLite/security/code-scanning/18](https://github.com/Azure-Samples/eShopLite/security/code-scanning/18)

To fix the issue, sanitize the `insight.Question` value before logging it. Since the log entries are plain text, remove newline characters and other potentially harmful characters from the user input. This can be achieved using `String.Replace` or similar methods. The sanitization should occur immediately before the logging statement to ensure that the logged value is safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
