### PR TITLE
Potential fix for code scanning alert no. 17: Log entries created from user input

### DIFF
--- a/scenarios/06-mcp/src/WeatherAgent/EndPoints/WeatherEndPoints.cs
+++ b/scenarios/06-mcp/src/WeatherAgent/EndPoints/WeatherEndPoints.cs
@@ -46,11 +46,12 @@ public static class WeatherEndPoints
 
             response.WeatherCondition =  weather is null
                 ? $"Could not retrieve weather data for {city}"
-                : $"Current temperature in {city} is {weather.temperature}°C with wind speed {weather.windspeed} km/h.";
+                : $"Current temperature in {city} is {weather.temperature}Â°C with wind speed {weather.windspeed} km/h.";
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, $"Error retrieving weather data for {city}");
+            var sanitizedCity = city.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+            logger.LogError(ex, $"Error retrieving weather data for {sanitizedCity}");
             response.WeatherCondition = $"Error retrieving weather data: {ex.Message}";
         }
         return response;


### PR DESCRIPTION
Potential fix for [https://github.com/Azure-Samples/eShopLite/security/code-scanning/17](https://github.com/Azure-Samples/eShopLite/security/code-scanning/17)

To fix the issue, the `city` parameter should be sanitized before being included in the log message. Since the log entries are likely plain text, newline characters and other potentially problematic characters should be removed or replaced. This can be achieved using `String.Replace` or similar methods. The sanitized value should then be used in the log message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
