### PR TITLE
Potential fix for code scanning alert no. 16: Log entries created from user input

### DIFF
--- a/scenarios/06-mcp/src/OnlineResearcher/EndPoints/OnlineResearchEndPoints.cs
+++ b/scenarios/06-mcp/src/OnlineResearcher/EndPoints/OnlineResearchEndPoints.cs
@@ -35,7 +35,8 @@ public static class OnlineResearchEndPoints
     internal static async Task<OnlineSearchToolResponse> SearchOnlineAsync(string query, ILogger<Program> logger, IConfiguration config)
     {
         logger.LogInformation("==========================");
-        logger.LogInformation($"Search online for the query: {query}");
+        var sanitizedQuery = query.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        logger.LogInformation($"Search online for the query: {sanitizedQuery}");
 
         // read settings from user secrets
         var tenantid = config["aifoundryproject_tenantid"];
@@ -96,7 +97,8 @@ public static class OnlineResearchEndPoints
 
         string searchResult = "";
         logger.LogInformation("==========================");
-        logger.LogInformation($"Search for '{query}'");
+        var sanitizedQuery = query.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        logger.LogInformation($"Search for '{sanitizedQuery}'");
 
         AsyncPageable<PersistentThreadMessage> messages = persistentClient.Messages.GetMessagesAsync(
 threadId: thread.Id, order: ListSortOrder.Ascending);


### PR DESCRIPTION
Potential fix for [https://github.com/Azure-Samples/eShopLite/security/code-scanning/16](https://github.com/Azure-Samples/eShopLite/security/code-scanning/16)

To fix the issue, the `query` parameter should be sanitized before being logged. Since the logs are plain text, newline characters and other special characters that could manipulate log entries should be removed. This can be achieved using `String.Replace` or similar methods to strip out problematic characters. The fix should be applied to all instances where `query` is logged, including line 99 and any other relevant lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
