### PR TITLE
Potential fix for code scanning alert no. 15: Log entries created from user input

### DIFF
--- a/scenarios/06-mcp/src/OnlineResearcher/EndPoints/OnlineResearchEndPoints.cs
+++ b/scenarios/06-mcp/src/OnlineResearcher/EndPoints/OnlineResearchEndPoints.cs
@@ -49,7 +49,8 @@ public static class OnlineResearchEndPoints
         logger.LogInformation($"AI Foundry Project - tenantid: {tenantid}");
         logger.LogInformation($"AI Foundry Project - searchagentid: {searchagentid}");
         logger.LogInformation($"AI Foundry Project - bingsearchconnectionName: {bingsearchconnectionName}");
-        logger.LogInformation($"AI Foundry Project - endpoint: {aifoundryproject_endpoint}");
+        var sanitizedEndpoint = aifoundryproject_endpoint?.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        logger.LogInformation($"AI Foundry Project - endpoint: {sanitizedEndpoint}");
 
         // create credential
         var options = new DefaultAzureCredentialOptions();


### PR DESCRIPTION
Potential fix for [https://github.com/Azure-Samples/eShopLite/security/code-scanning/15](https://github.com/Azure-Samples/eShopLite/security/code-scanning/15)

To fix the issue, the `aifoundryproject_endpoint` value should be sanitized before being logged. Since the log entries are plain text, we can remove any newline characters from the value using `String.Replace`. This ensures that malicious input cannot inject new log entries or manipulate the log format. Additionally, we should clearly mark user-provided values in the log to prevent confusion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
