### PR TITLE
Potential fix for code scanning alert no. 20: Log entries created from user input

### DIFF
--- a/scenarios/06-mcp/src/OnlineResearcher/EndPoints/OnlineResearchEndPoints.cs
+++ b/scenarios/06-mcp/src/OnlineResearcher/EndPoints/OnlineResearchEndPoints.cs
@@ -49,7 +49,8 @@ public static class OnlineResearchEndPoints
         logger.LogInformation($"Configuration values:");
         logger.LogInformation($"AI Foundry Project - tenantid: {tenantid}");
         logger.LogInformation($"AI Foundry Project - searchagentid: {searchagentid}");
-        logger.LogInformation($"AI Foundry Project - bingsearchconnectionName: {bingsearchconnectionName}");
+        var sanitizedBingSearchConnectionName = bingsearchconnectionName?.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        logger.LogInformation($"AI Foundry Project - bingsearchconnectionName: {sanitizedBingSearchConnectionName}");
         var sanitizedEndpoint = aifoundryproject_endpoint?.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
         logger.LogInformation($"AI Foundry Project - endpoint: {sanitizedEndpoint}");
 


### PR DESCRIPTION
Potential fix for [https://github.com/Azure-Samples/eShopLite/security/code-scanning/20](https://github.com/Azure-Samples/eShopLite/security/code-scanning/20)

To fix the issue, the `bingsearchconnectionName` value should be sanitized before being logged. This involves removing potentially harmful characters such as newlines (`\n`, `\r`) and ensuring the value is safe for inclusion in log entries. The `String.Replace` method can be used to remove these characters. This approach ensures that the log entry cannot be manipulated by malicious input.

The fix will involve modifying the logging statement on line 52 to use a sanitized version of `bingsearchconnectionName`. Additionally, the sanitization logic should be applied consistently to other configuration values logged in the same method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
