### PR TITLE
bump markdown-checker to 1.3.1

### DIFF
--- a/.github/workflows/validate-documentation-links.yml
+++ b/.github/workflows/validate-documentation-links.yml
@@ -19,43 +19,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Check broken Paths
-        uses: john0isaac/action-check-markdown@v1.1.0
+        uses: john0isaac/action-check-markdown@v1.3.1
         with:
           command: check_broken_paths
           directory: ./
-          guide-url: 'https://github.com/microsoft/Generative-AI-for-beginners-dotnet/blob/main/CONTRIBUTING.MD'
+          guide-url: 'https://github.com/Azure-Samples/eShopLite/blob/main/CONTRIBUTING.md'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   check-urls-locale:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Check URLs Country Locale
-        uses: john0isaac/action-check-markdown@v1.1.0
+        uses: john0isaac/action-check-markdown@v1.3.1
         with:
           command: check_urls_locale
           directory: ./
-          guide-url: 'https://github.com/microsoft/Generative-AI-for-beginners-dotnet/blob/main/CONTRIBUTING.MD'
+          guide-url: 'https://github.com/Azure-Samples/eShopLite/blob/main/CONTRIBUTING.md'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   check-broken-urls:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Check broken URLs
-        uses: john0isaac/action-check-markdown@v1.1.0
+        uses: john0isaac/action-check-markdown@v1.3.1
         with:
           command: check_broken_urls
           directory: ./
-          guide-url: 'https://github.com/microsoft/Generative-AI-for-beginners-dotnet/blob/main/CONTRIBUTING.MD'
+          guide-url: 'https://github.com/Azure-Samples/eShopLite/blob/main/CONTRIBUTING.md'
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hey 👋🏼,
Thank you for using the tool.
I recently used zizmor to audit the package and fixed all the issues it flagged.

This update includes:
- Sticky comments, only one comment will be posted per command used instead of spamming the pull request with every push.
- zizmor security fixes.
- Only posting comments to pull requests for push we update summary of job and mark it as failed/succeed.
- I pinned `markdown-checker` the python package behind this tool since I saw unpinned dependencies causing lots of issues everywhere.
- Due to `pull_request: write` GitHub restrictions it's no longer required since commenting won't work unless the pull request is not from a fork. only updating the summary and GitHub annotations.

For more info check: https://markdown-checker.readthedocs.io/en/latest/howto/github-actions/